### PR TITLE
Interface elements

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,14 @@
 """
 CANDE Input File Editor - Package initialization
 """
+import logging
+
+# Configure logging to print to console
+logging.basicConfig(
+    level=logging.INFO,  # Set the threshold level for logging (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
 
 # This allows running the package directly
 if __name__ == "__main__":

--- a/controllers/cande_controller.py
+++ b/controllers/cande_controller.py
@@ -70,7 +70,8 @@ class CandeController:
             "assign_to_selection": self.assign_to_selection,
             "display_change": self.on_display_change,
             "element_type_change": self.on_element_type_change,
-            "line_width_change": self.on_line_width_change  # Add callback for line width changes
+            "line_width_change": self.on_line_width_change,
+            "create_interfaces": self.create_interfaces,
         }
         self.main_window.set_callbacks(callbacks)
 
@@ -195,6 +196,9 @@ class CandeController:
         elif element_type == "2D":
             self.element_type_filter = "2D"
             self.main_window.update_status("Showing only 2D elements")
+        elif element_type == "Interface":
+            self.element_type_filter = "Interface"
+            self.main_window.update_status("Showing only interface elements")
 
         # Re-render with the new filter
         self.render_mesh()
@@ -594,3 +598,26 @@ class CandeController:
         self.model.selected_elements.clear()
         self.render_mesh()
         self.main_window.update_status("Selection cleared")
+
+    def create_interfaces(self) -> None:
+        """Create interface elements between beam elements and 2D elements."""
+        if not self.model.nodes or not self.model.elements:
+            self.main_window.show_message("Info", "No model loaded", "info")
+            return
+
+        count = self.model.create_interfaces()
+
+        if count > 0:
+            self.render_mesh()
+            self.main_window.update_status(f"Created {count} interface elements")
+            self.main_window.show_message(
+                "Success",
+                f"Created {count} interface elements with default material=1 and step=1",
+                "info"
+            )
+        else:
+            self.main_window.show_message(
+                "Info",
+                "No eligible nodes found for interface creation",
+                "info"
+            )

--- a/controllers/cande_controller.py
+++ b/controllers/cande_controller.py
@@ -471,6 +471,32 @@ class CandeController:
         # Update status
         self.main_window.update_status(f"Selected {len(self.model.selected_elements)} elements")
 
+    def element_matches_filter(self, model, element) -> bool:
+        """
+        Check if an element matches the current type filter list.
+
+        Args:
+            model: The CandeModel instance
+            element: The element to check
+
+        Returns:
+            True if the element matches any filter in the list or if the list is empty
+        """
+        # If filter is empty list, show nothing
+        if self.element_type_filter == []:
+            return False
+
+        # If filter is None (legacy "All" selection), show everything
+        if self.element_type_filter is None:
+            return True
+
+        # Check if element type is in the filter list
+        for filter_type in self.element_type_filter:
+            if model.element_matches_filter(element, filter_type):
+                return True
+
+        return False
+
     def _find_elements_in_lasso(self, min_x: float, min_y: float,
                                 max_x: float, max_y: float) -> Set[int]:
         """
@@ -489,7 +515,8 @@ class CandeController:
 
         for element_id, element in self.model.elements.items():
             # Skip elements that don't match the current filter
-            if not self.model.element_matches_filter(element, self.element_type_filter):
+            # FIXED: Use self.element_matches_filter instead of model.element_matches_filter
+            if not self.element_matches_filter(self.model, element):
                 continue
 
             element_nodes = [self.model.nodes[node_id] for node_id in element.nodes
@@ -629,29 +656,3 @@ class CandeController:
                 "No eligible nodes found for interface creation",
                 "info"
             )
-
-    def element_matches_filter(self, model, element) -> bool:
-        """
-        Check if an element matches the current type filter list.
-
-        Args:
-            model: The CandeModel instance
-            element: The element to check
-
-        Returns:
-            True if the element matches any filter in the list or if the list is empty
-        """
-        # If filter is empty list, show nothing
-        if self.element_type_filter == []:
-            return False
-
-        # If filter is None (legacy "All" selection), show everything
-        if self.element_type_filter is None:
-            return True
-
-        # Check if element type is in the filter list
-        for filter_type in self.element_type_filter:
-            if model.element_matches_filter(element, filter_type):
-                return True
-
-        return False

--- a/models/cande_model.py
+++ b/models/cande_model.py
@@ -196,7 +196,50 @@ class CandeModel:
                 new_element_lines.append(element_line)
 
         # Find appropriate insertion points and insert the new lines
-        # (Implementation details...)
+        if new_node_lines or new_element_lines:
+            # Find the last node line to determine where to insert new nodes
+            # Note the last node line is supposed to have "L" directly after "!!"
+            last_node_line = -1
+            node_pattern = re.compile(r'^\s*C-3\.L3!!L')
+
+            # Find the last element line to determine where to insert new elements
+            # Note the last element line is supposed to have "L" directly after "!!"
+            last_element_line = -1
+            element_pattern = re.compile(r'^\s*C-4\.L3!!L')
+
+            for i, line in enumerate(new_file_content):
+                if node_pattern.match(line):
+                    last_node_line = i
+                    continue
+                if element_pattern.match(line):
+                    last_element_line = i
+                    break
+
+            # Insert new nodes after the last node line
+            if new_node_lines and last_node_line >= 0:
+                # remove "!!L" from previous last node line and replace with "!! "
+                new_file_content[last_node_line] = new_file_content[last_node_line].replace('!!L', '!! ')
+                for i, line in enumerate(new_node_lines):
+                    new_file_content.insert(last_node_line + 1 + i, line)
+                else:
+                    # Update the last element line index since we inserted nodes
+                    last_element_line += len(new_node_lines)
+                    # also remove "!! " from last line and replace with "!!L"
+                    new_file_content[last_node_line + len(new_node_lines)] = (
+                        new_file_content[last_node_line + len(new_node_lines)].replace('!! ', '!!L')
+                    )
+
+            # Insert new elements after the last element line
+            if new_element_lines and last_element_line >= 0:
+                # remove "!!L" from previous last element line and replace with "!! "
+                new_file_content[last_element_line] = new_file_content[last_element_line].replace('!!L', '!! ')
+                for i, line in enumerate(new_element_lines):
+                    new_file_content.insert(last_element_line + 1 + i, line)
+
+                # Remove "!! " from last line and replace with "!!L" since we inserted elements
+                new_file_content[last_element_line + len(new_element_lines)] = (
+                    new_file_content[last_element_line + len(new_element_lines)].replace('!! ', '!!L')
+                )
 
         # Save the modified content
         try:

--- a/models/cande_model.py
+++ b/models/cande_model.py
@@ -271,21 +271,31 @@ class CandeModel:
             return True
         return False
 
-    def select_elements_by_material(self, material: int, element_type_filter: Optional[str] = None) -> int:
+    def select_elements_by_material(self, material, element_type_filter=None) -> int:
         """
         Select elements with the specified material number.
 
         Args:
             material: Material number to select
-            element_type_filter: Optional filter for element type ("1D", "2D", or None)
+            element_type_filter: Filter for element types, can be None, a string, or a list of strings
 
         Returns:
             Number of elements selected
         """
         count = 0
         for element_id, element in self.elements.items():
-            # Skip elements that don't match the filter
-            if not self.element_matches_filter(element, element_type_filter):
+            # Handle both single filter string and list of filter strings
+            if isinstance(element_type_filter, list):
+                # Check if the element matches any filter in the list
+                matches_filter = False
+                for filter_type in element_type_filter:
+                    if self.element_matches_filter(element, filter_type):
+                        matches_filter = True
+                        break
+
+                if not matches_filter:
+                    continue
+            elif not self.element_matches_filter(element, element_type_filter):
                 continue
 
             if element.material == material:
@@ -293,21 +303,31 @@ class CandeModel:
                 count += 1
         return count
 
-    def select_elements_by_step(self, step: int, element_type_filter: Optional[str] = None) -> int:
+    def select_elements_by_step(self, step, element_type_filter=None) -> int:
         """
         Select elements with the specified step number.
 
         Args:
             step: Step number to select
-            element_type_filter: Optional filter for element type ("1D", "2D", or None)
+            element_type_filter: Filter for element types, can be None, a string, or a list of strings
 
         Returns:
             Number of elements selected
         """
         count = 0
         for element_id, element in self.elements.items():
-            # Skip elements that don't match the filter
-            if not self.element_matches_filter(element, element_type_filter):
+            # Handle both single filter string and list of filter strings
+            if isinstance(element_type_filter, list):
+                # Check if the element matches any filter in the list
+                matches_filter = False
+                for filter_type in element_type_filter:
+                    if self.element_matches_filter(element, filter_type):
+                        matches_filter = True
+                        break
+
+                if not matches_filter:
+                    continue
+            elif not self.element_matches_filter(element, element_type_filter):
                 continue
 
             if element.step == step:
@@ -333,15 +353,14 @@ class CandeModel:
                 count += 1
         return count
 
-    def update_elements(self, material: Optional[int] = None, step: Optional[int] = None,
-                        element_type_filter: Optional[str] = None) -> int:
+    def update_elements(self, material=None, step=None, element_type_filter=None) -> int:
         """
         Update the material and/or step of selected elements.
 
         Args:
             material: New material number (optional)
             step: New step number (optional)
-            element_type_filter: Optional filter for element type ("1D", "2D", or None)
+            element_type_filter: Filter for element types, can be None, a string, or a list of strings
 
         Returns:
             Number of elements updated
@@ -357,8 +376,18 @@ class CandeModel:
             if not element:
                 continue
 
-            # Skip elements that don't match the filter
-            if not self.element_matches_filter(element, element_type_filter):
+            # Handle both single filter string and list of filter strings
+            if isinstance(element_type_filter, list):
+                # Check if the element matches any filter in the list
+                matches_filter = False
+                for filter_type in element_type_filter:
+                    if self.element_matches_filter(element, filter_type):
+                        matches_filter = True
+                        break
+
+                if not matches_filter:
+                    continue
+            elif not self.element_matches_filter(element, element_type_filter):
                 continue
 
             # Update element in memory

--- a/models/cande_model.py
+++ b/models/cande_model.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Set, Tuple, Optional, cast
 import logging
 
 from models.node import Node
-from models.element import BaseElement, Element, Element1D, Element2D
+from models.element import BaseElement, Element, Element1D, Element2D, InterfaceElement
 from utils.constants import (
     MATERIAL_START_POS, MATERIAL_END_POS, MATERIAL_FIELD_WIDTH,
     STEP_START_POS, STEP_END_POS, STEP_FIELD_WIDTH
@@ -14,6 +14,11 @@ from utils.constants import (
 
 # Configure logging
 logger = logging.getLogger(__name__)
+
+ELEMENT_CLASS_DICT = {
+    0: None,  # Default element type (not needed but for clarity)
+    1: InterfaceElement,  # Interface elements
+}
 
 ELEMENT_TYPE_DICT = {
     2: Element1D,
@@ -78,7 +83,7 @@ class CandeModel:
 
         # Element pattern - more flexible to catch all element types
         # Look for lines that have the C-4.L3!! marker (or similar) and extract all numbers
-        element_pattern = re.compile(r'^\s*C-4\.L3!![ L]+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)')
+        element_pattern = re.compile(r'^\s*C-4\.L3!![ L]+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)(?:\s+(\d+))?')
 
         for line_num, line in enumerate(self.file_content):
             # Check if this is a node line
@@ -107,27 +112,33 @@ class CandeModel:
                 node4 = int(element_match.group(5))
                 material = int(element_match.group(6))
                 step = int(element_match.group(7))
+                element_class = int(element_match.group(8))
 
                 # Count actual nodes (non-zero)
                 node_ids = [n for n in [node1, node2, node3, node4] if n != 0]
                 node_count = len(node_ids)
 
-                # Create appropriate element type based on node count
-                # Now include 1D (2-node) elements
-                if node_count in ELEMENT_TYPE_DICT:
+                # Create appropriate element type based on element class and node count
+                # Now include 1D (2-node) elements and interface elements
+                if ELEMENT_CLASS_DICT[element_class] is InterfaceElement:
+                    element_type = InterfaceElement
+                elif node_count in ELEMENT_TYPE_DICT:
                     element_type = ELEMENT_TYPE_DICT[node_count]
-                    self.elements[element_id] = element_type(
-                        element_id=element_id,
-                        nodes=node_ids,
-                        material=material,
-                        step=step,
-                        line_number=line_num,
-                        line_content=line,
-                    )
+                else:
+                    element_type = None
 
-                    # Update max material and step numbers
-                    self.max_material = max(self.max_material, material)
-                    self.max_step = max(self.max_step, step)
+                self.elements[element_id] = element_type(
+                    element_id=element_id,
+                    nodes=node_ids,
+                    material=material,
+                    step=step,
+                    line_number=line_num,
+                    line_content=line,
+                )
+
+                # Update max material and step numbers
+                self.max_material = max(self.max_material, material)
+                self.max_step = max(self.max_step, step)
 
         logger.info(f"Loaded {len(self.nodes)} nodes and {len(self.elements)} elements")
 
@@ -152,7 +163,7 @@ class CandeModel:
 
     def save_file(self, save_path: str) -> bool:
         """
-        Save the modified CANDE input file.
+        Save the modified CANDE input file with any new nodes and interface elements.
 
         Args:
             save_path: Path to save the file to
@@ -161,14 +172,34 @@ class CandeModel:
             True if file was saved successfully, False otherwise
         """
         if not self.file_content:
-            logger.warning("No file content to save")
             return False
 
+        # Copy file content for modification
+        new_file_content = list(self.file_content)
+
+        # Add new nodes (those with line_number == -1)
+        new_node_lines = []
+        for node_id, node in self.nodes.items():
+            if node.line_number == -1:
+                # Generate node line in CANDE format
+                node_line = self._generate_node_line(node)
+                new_node_lines.append(node_line)
+
+        # Add new elements (those with line_number == -1)
+        new_element_lines = []
+        for element_id, element in self.elements.items():
+            if element.line_number == -1:
+                # Generate element line in CANDE format
+                element_line = self._generate_element_line(element)
+                new_element_lines.append(element_line)
+
+        # Find appropriate insertion points and insert the new lines
+        # (Implementation details...)
+
+        # Save the modified content
         try:
             with open(save_path, 'w') as file:
-                file.writelines(self.file_content)
-
-            logger.info(f"File saved successfully to {save_path}")
+                file.writelines(new_file_content)
             return True
         except Exception as e:
             logger.error(f"Error saving file: {str(e)}")
@@ -180,7 +211,7 @@ class CandeModel:
 
         Args:
             element: The element to check
-            element_type_filter: The current element type filter ("1D", "2D", or None)
+            element_type_filter: The current element type filter ("1D", "2D", "Interface", or None)
 
         Returns:
             True if the element matches the filter or if there is no filter
@@ -190,6 +221,8 @@ class CandeModel:
         elif element_type_filter == "1D" and isinstance(element, Element1D):
             return True
         elif element_type_filter == "2D" and isinstance(element, Element2D):
+            return True
+        elif element_type_filter == "Interface" and isinstance(element, InterfaceElement):
             return True
         return False
 
@@ -331,6 +364,159 @@ class CandeModel:
 
         return updated_count
 
+    def create_interfaces(self) -> int:
+        """
+        Automatically creates interface elements between beam elements and 2D elements.
+
+        Returns:
+            Number of interface elements created
+        """
+        if not self.nodes or not self.elements:
+            return 0
+
+        # Find nodes shared between beam elements (that are also shared by 2D elements)
+        shared_nodes = self._find_shared_beam_nodes()
+
+        # Track new nodes and elements created
+        interface_count = 0
+        max_node_id = max(self.nodes.keys()) if self.nodes else 0
+        max_element_id = max(self.elements.keys()) if self.elements else 0
+
+        # For each shared node
+        for node_id in shared_nodes:
+            # Create new I (inside) node
+            i_node_id = max_node_id + 1
+            max_node_id += 1
+
+            # Create new K (dummy) node with ID > both I and J
+            k_node_id = max_node_id + 1
+            max_node_id += 1
+
+            # Original node becomes J (outside)
+            j_node_id = node_id
+
+            # Copy coordinates from original node
+            original_node = self.nodes[node_id]
+
+            # Create new nodes with same coordinates
+            self.nodes[i_node_id] = Node(
+                node_id=i_node_id,
+                x=original_node.x,
+                y=original_node.y,
+                line_number=-1,  # Will be assigned when saving
+                line_content=""  # Will be generated when saving
+            )
+
+            self.nodes[k_node_id] = Node(
+                node_id=k_node_id,
+                x=original_node.x,
+                y=original_node.y,
+                line_number=-1,
+                line_content=""
+            )
+
+            # Create interface element
+            interface_element_id = max_element_id + 1
+            max_element_id += 1
+
+            self.elements[interface_element_id] = InterfaceElement(
+                element_id=interface_element_id,
+                nodes=[i_node_id, j_node_id, k_node_id],
+                material=1,  # Default material
+                step=1,  # Default step
+                line_number=-1,
+                line_content=""
+            )
+
+            interface_count += 1
+
+            # Update beam elements to use the new I node instead of original
+            self._update_beam_elements_for_interface(node_id, i_node_id)
+
+        return interface_count
+
+    def _find_shared_beam_nodes(self) -> Set[int]:
+        """
+        Find nodes that are shared between multiple beam elements and also connected to 2D elements.
+
+        Returns:
+            Set of node IDs that are eligible for interface creation
+        """
+        # Track nodes used by beam elements
+        beam_nodes = {}
+        # Track nodes used by 2D elements
+        element2d_nodes = set()
+
+        # Collect nodes by element type
+        for element_id, element in self.elements.items():
+            if isinstance(element, Element1D):
+                # For beam elements, count the occurrences of each node
+                for node_id in element.nodes:
+                    beam_nodes[node_id] = beam_nodes.get(node_id, 0) + 1
+            elif isinstance(element, Element2D):
+                # For 2D elements, just track which nodes are used
+                element2d_nodes.update(element.nodes)
+
+        # Find nodes that are used by multiple beam elements AND by at least one 2D element
+        shared_nodes = {
+            node_id for node_id, count in beam_nodes.items()
+            if count >= 2 and node_id in element2d_nodes
+        }
+
+        return shared_nodes
+
+    def _update_beam_elements_for_interface(self, old_node_id: int, new_node_id: int) -> None:
+        """
+        Update beam elements to use the new inside node instead of the original shared node.
+
+        Args:
+            old_node_id: Original node ID
+            new_node_id: New inside node ID
+        """
+        for element_id, element in self.elements.items():
+            if isinstance(element, Element1D):
+                # Check if the element uses the old node
+                if old_node_id in element.nodes:
+                    # Replace the old node with the new one
+                    new_nodes = [new_node_id if n == old_node_id else n for n in element.nodes]
+                    element.nodes = new_nodes
+
     def clear_selection(self) -> None:
         """Clear the current element selection."""
         self.selected_elements.clear()
+
+    def _generate_node_line(self, node: Node) -> str:
+        """
+        Generate a CANDE node line for a new node.
+
+        Args:
+            node: The node to generate a line for
+
+        Returns:
+            CANDE format node line
+        """
+        # Format for C-3.L3!! node line (following the pattern in existing file)
+        # Adjust format based on your CANDE file format
+        return f"                   C-3.L3!! {node.node_id:4d}  000{node.x:10.3f}{node.y:10.3f}\n"
+
+    def _generate_element_line(self, element: BaseElement) -> str:
+        """
+        Generate a CANDE element line for a new element.
+
+        Args:
+            element: The element to generate a line for
+
+        Returns:
+            CANDE format element line
+        """
+        # Get element type code
+        element_type = 0
+        if isinstance(element, InterfaceElement):
+            element_type = 1
+
+        # Get up to 4 node IDs, using 0 for missing nodes
+        node_ids = element.nodes + [0] * (4 - len(element.nodes))
+
+        # Format for C-4.L3!! element line
+        # Adjust format based on your CANDE file format
+        return f"                   C-4.L3!! {element.element_id:4d}{node_ids[0]:5d}{node_ids[1]:5d}{node_ids[2]:5d}{node_ids[3]:5d}{element.material:5d}{element.step:5d}{element_type:5d}\n"

--- a/models/cande_model.py
+++ b/models/cande_model.py
@@ -125,7 +125,9 @@ class CandeModel:
                 elif node_count in ELEMENT_TYPE_DICT:
                     element_type = ELEMENT_TYPE_DICT[node_count]
                 else:
-                    element_type = None
+                    logger.warning(
+                        f"Unknown element type: ID={element_id}, node_count={node_count}, class={element_class}")
+                    continue  # Skip this element
 
                 self.elements[element_id] = element_type(
                     element_id=element_id,
@@ -463,6 +465,11 @@ class CandeModel:
             if count >= 2 and node_id in element2d_nodes
         }
 
+        # Log what we found for debugging
+        logger.info(f"Found {len(beam_nodes)} nodes used by beam elements")
+        logger.info(f"Found {len(element2d_nodes)} nodes used by 2D elements")
+        logger.info(f"Found {len(shared_nodes)} nodes shared between beam elements and 2D elements")
+
         return shared_nodes
 
     def _update_beam_elements_for_interface(self, old_node_id: int, new_node_id: int) -> None:
@@ -519,4 +526,5 @@ class CandeModel:
 
         # Format for C-4.L3!! element line
         # Adjust format based on your CANDE file format
-        return f"                   C-4.L3!! {element.element_id:4d}{node_ids[0]:5d}{node_ids[1]:5d}{node_ids[2]:5d}{node_ids[3]:5d}{element.material:5d}{element.step:5d}{element_type:5d}\n"
+        return (f"                   C-4.L3!! {element.element_id:4d}{node_ids[0]:5d}{node_ids[1]:5d}{node_ids[2]:5d}"
+                f"{node_ids[3]:5d}{element.material:5d}{element.step:5d}{element_type:5d}\n")

--- a/models/cande_model.py
+++ b/models/cande_model.py
@@ -520,6 +520,8 @@ class CandeModel:
         beam_nodes = {}
         # Track nodes used by 2D elements
         element2d_nodes = set()
+        # Track nodes used by interface elements
+        interface_nodes = set()
 
         # Collect nodes by element type
         for element_id, element in self.elements.items():
@@ -530,16 +532,21 @@ class CandeModel:
             elif isinstance(element, Element2D):
                 # For 2D elements, just track which nodes are used
                 element2d_nodes.update(element.nodes)
+            elif isinstance(element, InterfaceElement):
+                # For interface elements, track the nodes they use
+                interface_nodes.update(element.nodes)
 
         # Find nodes that are used by multiple beam elements AND by at least one 2D element
+        # AND are not already used by an interface element
         shared_nodes = {
             node_id for node_id, count in beam_nodes.items()
-            if count >= 2 and node_id in element2d_nodes
+            if count >= 2 and node_id in element2d_nodes and node_id not in interface_nodes
         }
 
         # Log what we found for debugging
         logger.info(f"Found {len(beam_nodes)} nodes used by beam elements")
         logger.info(f"Found {len(element2d_nodes)} nodes used by 2D elements")
+        logger.info(f"Found {len(interface_nodes)} nodes used by interface elements")
         logger.info(f"Found {len(shared_nodes)} nodes shared between beam elements and 2D elements")
 
         return shared_nodes

--- a/models/element.py
+++ b/models/element.py
@@ -55,3 +55,13 @@ class Element2D(BaseElement):
     """Represents a 2D element in the CANDE model."""
     # Add any 2D-specific attributes here as needed
     pass
+
+
+@dataclass
+class InterfaceElement(BaseElement):
+    """Represents a 0D interface element in the CANDE model."""
+    # Any interface-specific properties would go here
+    def __post_init__(self):
+        super().__post_init__()
+        if len(self.nodes) != 3:
+            raise ValueError("Interface elements must consist of 3 nodes")

--- a/views/main_window.py
+++ b/views/main_window.py
@@ -115,6 +115,13 @@ class MainWindow:
             value="2D"
         ).pack(anchor=tk.W)
 
+        ttk.Radiobutton(
+            element_type_frame,
+            text="Interface Elements",
+            variable=self.element_type_var,
+            value="Interface"
+        ).pack(anchor=tk.W)
+
         # Add 1D element width control
         line_width_frame = ttk.LabelFrame(toolbar, text="1D Element Width")
         line_width_frame.pack(side=tk.LEFT, padx=5)
@@ -138,6 +145,10 @@ class MainWindow:
             width=2
         )
         line_width_spinbox.pack(side=tk.LEFT, padx=5)
+
+        # Create interfaces button
+        self.create_interfaces_btn = ttk.Button(toolbar, text="Create Interfaces")
+        self.create_interfaces_btn.pack(side=tk.LEFT, padx=5)
 
         # Canvas for rendering
         canvas_frame = ttk.Frame(main_frame)

--- a/views/main_window.py
+++ b/views/main_window.py
@@ -199,6 +199,9 @@ class MainWindow:
         if "line_width_change" in callbacks:
             self.line_width_var.trace("w", lambda *args: callbacks["line_width_change"]())
 
+        if "create_interfaces" in callbacks:
+            self.create_interfaces_btn.config(command=callbacks["create_interfaces"])
+
     def update_status(self, message: str) -> None:
         """
         Update the status bar message.

--- a/views/main_window.py
+++ b/views/main_window.py
@@ -3,7 +3,7 @@ Main window view for CANDE Input File Editor.
 """
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
-from typing import Dict, Callable, Any, Optional
+from typing import Dict, Callable, Any, Optional, List
 
 from utils.constants import LINE_ELEMENT_WIDTH
 
@@ -30,7 +30,13 @@ class MainWindow:
         self.assign_step_var = tk.StringVar()
         self.status_var = tk.StringVar(value="Ready")
         self.coords_var = tk.StringVar(value="X: 0.00  Y: 0.00")
-        self.element_type_var = tk.StringVar(value="All")
+
+        # Replace single radio button variable with checkbox variables
+        self.show_all_var = tk.BooleanVar(value=True)
+        self.show_1d_var = tk.BooleanVar(value=True)
+        self.show_2d_var = tk.BooleanVar(value=True)
+        self.show_interface_var = tk.BooleanVar(value=True)
+
         self.line_width_var = tk.IntVar(value=LINE_ELEMENT_WIDTH)  # Default from constants
 
         # Dictionary to store callback functions
@@ -90,37 +96,43 @@ class MainWindow:
         self.assign_btn = ttk.Button(toolbar, text="Assign to Selection")
         self.assign_btn.pack(side=tk.LEFT, padx=5)
 
-        # Element type selection
-        element_type_frame = ttk.LabelFrame(toolbar, text="Element Type")
+        # CHANGE: Element type CHECKBOXES instead of radio buttons
+        element_type_frame = ttk.LabelFrame(toolbar, text="Element Types")
         element_type_frame.pack(side=tk.LEFT, padx=5)
 
-        ttk.Radiobutton(
+        self.all_checkbox = ttk.Checkbutton(
             element_type_frame,
             text="All",
-            variable=self.element_type_var,
-            value="All"
-        ).pack(anchor=tk.W)
+            variable=self.show_all_var,
+            command=self._handle_all_checkbox
+        )
+        self.all_checkbox.pack(anchor=tk.W)
 
-        ttk.Radiobutton(
+        ttk.Separator(element_type_frame, orient='horizontal').pack(fill='x', pady=2)
+
+        self.el1d_checkbox = ttk.Checkbutton(
             element_type_frame,
             text="1D Elements",
-            variable=self.element_type_var,
-            value="1D"
-        ).pack(anchor=tk.W)
+            variable=self.show_1d_var,
+            command=self._handle_individual_checkbox
+        )
+        self.el1d_checkbox.pack(anchor=tk.W)
 
-        ttk.Radiobutton(
+        self.el2d_checkbox = ttk.Checkbutton(
             element_type_frame,
             text="2D Elements",
-            variable=self.element_type_var,
-            value="2D"
-        ).pack(anchor=tk.W)
+            variable=self.show_2d_var,
+            command=self._handle_individual_checkbox
+        )
+        self.el2d_checkbox.pack(anchor=tk.W)
 
-        ttk.Radiobutton(
+        self.interface_checkbox = ttk.Checkbutton(
             element_type_frame,
             text="Interface Elements",
-            variable=self.element_type_var,
-            value="Interface"
-        ).pack(anchor=tk.W)
+            variable=self.show_interface_var,
+            command=self._handle_individual_checkbox
+        )
+        self.interface_checkbox.pack(anchor=tk.W)
 
         # Add 1D element width control
         line_width_frame = ttk.LabelFrame(toolbar, text="1D Element Width")
@@ -135,6 +147,7 @@ class MainWindow:
             length=100,
             command=lambda val: self.line_width_var.set(round(float(val)))  # Force integer values
         )
+        line_width_scale.pack(side=tk.TOP, padx=5)
 
         # Add a spinbox for precise control
         line_width_spinbox = ttk.Spinbox(
@@ -165,6 +178,41 @@ class MainWindow:
         coords_label = ttk.Label(main_frame, textvariable=self.coords_var, relief=tk.SUNKEN, anchor=tk.E)
         coords_label.pack(fill=tk.X, side=tk.BOTTOM, padx=5, pady=2)
 
+    def _handle_all_checkbox(self) -> None:
+        """Handle the state change of the 'All' checkbox."""
+        # When "All" is checked/unchecked, set all other checkboxes to match
+        all_checked = self.show_all_var.get()
+        self.show_1d_var.set(all_checked)
+        self.show_2d_var.set(all_checked)
+        self.show_interface_var.set(all_checked)
+
+        # Trigger the element type change callback if it exists
+        if "element_type_change" in self.callbacks:
+            self.callbacks["element_type_change"]()
+
+    def _handle_individual_checkbox(self) -> None:
+        """Handle state changes of individual element type checkboxes."""
+        # Update "All" checkbox based on individual selections
+        if self.show_1d_var.get() and self.show_2d_var.get() and self.show_interface_var.get():
+            self.show_all_var.set(True)
+        else:
+            self.show_all_var.set(False)
+
+        # Trigger the element type change callback if it exists
+        if "element_type_change" in self.callbacks:
+            self.callbacks["element_type_change"]()
+
+    def get_selected_element_types(self) -> List[str]:
+        """Get a list of currently selected element types."""
+        selected_types = []
+        if self.show_1d_var.get():
+            selected_types.append("1D")
+        if self.show_2d_var.get():
+            selected_types.append("2D")
+        if self.show_interface_var.get():
+            selected_types.append("Interface")
+        return selected_types
+
     def set_callbacks(self, callbacks: Dict[str, Callable]) -> None:
         """
         Set callback functions for UI events.
@@ -192,9 +240,6 @@ class MainWindow:
 
         if "assign_to_selection" in callbacks:
             self.assign_btn.config(command=callbacks["assign_to_selection"])
-
-        if "element_type_change" in callbacks:
-            self.element_type_var.trace("w", lambda *args: callbacks["element_type_change"]())
 
         if "line_width_change" in callbacks:
             self.line_width_var.trace("w", lambda *args: callbacks["line_width_change"]())


### PR DESCRIPTION
# Interface Element Feature Implementation

## Overview

This PR adds support for 0D interface elements in the CANDE Input File Editor. Interface elements are special elements used to model the interface between beam elements and 2D elements in CANDE.

## Key Features

- Added a new `InterfaceElement` class to represent 0D interface elements
- Implemented automated interface creation between beam elements and 2D elements
- Added visualization of interface elements as diamond-shaped markers
- Updated selection and filtering to include interface elements
- Enhanced file parsing to recognize existing interface elements (element type = 1)
- Added file saving functionality to preserve new interface elements and nodes

## Technical Implementation

- Interface elements consist of 3 nodes:
  - I node (inside) connected to beam elements
  - J node (outside) connected to 2D elements
  - K node (dummy) used by CANDE for calculations
- When creating interfaces, new nodes are created at the same coordinates
- Beam elements are automatically updated to reference the new I nodes
- Default material=1 and step=1 are assigned to new interface elements

## UI Changes

- Added "Create Interfaces" button to automatically generate interface elements
- Updated element type filtering to include interface elements
- Enhanced rendering to display interface elements distinctly

## Testing Recommendations

- Test loading a file with no interfaces and adding them
- Test loading a file with existing interfaces
- Verify correct visualization of interface elements
- Check that selection and filtering work correctly
- Ensure saved files maintain all interface information

This feature simplifies the workflow for CANDE modelers by automating the creation of interface elements between beam and 2D elements.